### PR TITLE
Add hook manager and projection edit utility

### DIFF
--- a/scripts/apply_edit_and_eval.sh
+++ b/scripts/apply_edit_and_eval.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 . .venv/bin/activate || true
-python -m clip_causal_repair.feature_edit apply   --arch ViT-B-32   --pretrained laion2b_s34b_b79k   --root data/wilds   --direction edits/water_direction.npy   --layer final   --alpha 1.0   --eval-split test   --out outputs/after_edit.csv
+
+python -m clip_causal_repair.feature_edit apply \
+  --arch ViT-B-32 \
+  --pretrained laion2b_s34b_b79k \
+  --root data/wilds \
+  --direction edits/water_direction.npy \
+  --layer visual \
+  --alpha 1.0 \
+  --eval-split test \
+  --out outputs/after_edit.csv

--- a/scripts/fit_direction.sh
+++ b/scripts/fit_direction.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 . .venv/bin/activate || true
-python -m clip_causal_repair.feature_edit fit-direction   --arch ViT-B-32   --pretrained laion2b_s34b_b79k   --root data/wilds   --split train   --max-samples 2000   --out edits/water_direction.npy
+
+python -m clip_causal_repair.feature_edit fit-direction \
+  --arch ViT-B-32 \
+  --pretrained laion2b_s34b_b79k \
+  --root data/wilds \
+  --split train \
+  --max-samples 2000 \
+  --out edits/water_direction.npy

--- a/src/clip_causal_repair/__init__.py
+++ b/src/clip_causal_repair/__init__.py
@@ -1,1 +1,6 @@
-__all__ = []
+"""Public API for clip_causal_repair."""
+
+from .hooks import HookManager, LayerAddress, tensor_edit_projection_out
+
+__all__ = ["HookManager", "LayerAddress", "tensor_edit_projection_out"]
+

--- a/src/clip_causal_repair/feature_edit.py
+++ b/src/clip_causal_repair/feature_edit.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 from .clip_loader import load_clip, encode_text, encode_images
 from .waterbirds import get_waterbirds, make_loader
 from .group_metrics import group_report
+from .hooks import HookManager, LayerAddress, tensor_edit_projection_out
 
 
 @torch.no_grad()
@@ -42,31 +43,6 @@ def fit_direction_from_metadata(features: np.ndarray, metadata: np.ndarray, meta
     return w.astype(np.float32)
 
 
-class ProjectionEdit:
-    def __init__(self, direction: np.ndarray, alpha: float = 1.0):
-        self.u = torch.tensor(direction, dtype=torch.float32)
-        self.alpha = alpha
-        self.handle = None
-
-    def _hook(self, module, inputs, output):
-        assert output.shape[-1] == self.u.numel(), \
-        f"edit dir dim {self.u.numel()} != output dim {output.shape[-1]}"
-        # output: [B, D] where D is the embed dim (512 for ViT-B/32)
-        u = self.u.to(output.device, dtype=output.dtype)
-        u = u / (u.norm() + 1e-12)
-        # subtract component along u
-        proj = (output @ u).unsqueeze(1) * u.unsqueeze(0)
-        return output - self.alpha * proj  # return new output (no in-place ops)
-
-    def apply(self, model):
-        self.handle = model.visual.register_forward_hook(self._hook)
-
-    def remove(self):
-        if self.handle is not None:
-            self.handle.remove()
-            self.handle = None
-
-
 def cmd_fit_direction(arch, pretrained, root, split, max_samples, batch_size, out):
     model, preprocess, tokenizer, device = load_clip(arch, pretrained)
     subset, metadata_fields = get_waterbirds(root, split, transform=preprocess)
@@ -84,7 +60,7 @@ def cmd_fit_direction(arch, pretrained, root, split, max_samples, batch_size, ou
     print(f"✅ Saved direction to {out}")
 
 
-def cmd_apply(arch, pretrained, root, direction, layer, alpha, eval_split, batch_size, out):
+def cmd_apply(arch, pretrained, root, direction, layers, alpha, eval_split, batch_size, out):
     """
     Apply a directional edit to the CLIP model and evaluate its performance on a specified dataset split.
 
@@ -94,7 +70,9 @@ def cmd_apply(arch, pretrained, root, direction, layer, alpha, eval_split, batch
     - pretrained (str): Pretrained weights identifier.
     - root (str): Path to the dataset root.
     - direction (str): Filepath to the saved direction vector.
-    - layer (str): Layer to apply the edit to.
+    - layers (list[str]): Layer addresses to apply the edit to. Each should
+      correspond to a dotted module path in the model. The special keyword
+      ``"final"`` maps to ``"visual"`` (the final visual features).
     - alpha (float): Scaling factor for the edit.
     - eval_split (str): Dataset split for evaluation.
     - batch_size (int): Batch size for data loading.
@@ -115,10 +93,19 @@ def cmd_apply(arch, pretrained, root, direction, layer, alpha, eval_split, batch
     Saves a CSV file with per-group evaluation metrics and prints overall and worst-group accuracies.
     """
     model, preprocess, tokenizer, device = load_clip(arch, pretrained)
-    direction = np.load(direction)
+    direction = torch.tensor(np.load(direction), dtype=torch.float32)
 
-    edit = ProjectionEdit(direction, alpha=alpha)
-    edit.apply(model)
+    # resolve layer names; allow legacy "final" keyword
+    layer_names = ["visual" if l == "final" else l for l in layers]
+    addresses = [LayerAddress(name) for name in layer_names]
+
+    hook_mgr = HookManager(model)
+
+    def _hook(module, inputs, output):
+        u = direction.to(output.device, dtype=output.dtype)
+        return tensor_edit_projection_out(output, u, alpha)
+
+    hook_mgr.register(addresses, _hook)
 
     prompts = ["a photo of a landbird", "a photo of a waterbird"]
     text_feats = encode_text(model, tokenizer, prompts, device)
@@ -147,7 +134,7 @@ def cmd_apply(arch, pretrained, root, direction, layer, alpha, eval_split, batch
     df.to_csv(out, index=False)
     print(f"Overall acc (after edit): {overall:.3f}\nWorst-group acc (after edit): {worst:.3f}\nSaved per-group to: {out}")
 
-    edit.remove()
+    hook_mgr.remove()
 
 
 def main():
@@ -168,7 +155,13 @@ def main():
     app.add_argument("--pretrained", type=str, default="laion2b_s34b_b79k")
     app.add_argument("--root", type=str, default="data/wilds")
     app.add_argument("--direction", type=str, required=True)
-    app.add_argument("--layer", type=str, default="final")
+    app.add_argument(
+        "--layer",
+        dest="layers",
+        action="append",
+        default=["visual"],
+        help="Layer address to edit; may be provided multiple times",
+    )
     app.add_argument("--alpha", type=float, default=1.0)
     app.add_argument("--eval-split", type=str, default="test")
     app.add_argument("--batch-size", type=int, default=64)
@@ -179,7 +172,17 @@ def main():
     if args.cmd == "fit-direction":
         cmd_fit_direction(args.arch, args.pretrained, args.root, args.split, args.max_samples, args.batch_size, args.out)
     elif args.cmd == "apply":
-        cmd_apply(args.arch, args.pretrained, args.root, args.direction, args.layer, args.alpha, args.eval_split, args.batch_size, args.out)
+        cmd_apply(
+            args.arch,
+            args.pretrained,
+            args.root,
+            args.direction,
+            args.layers,
+            args.alpha,
+            args.eval_split,
+            args.batch_size,
+            args.out,
+        )
 
 
 if __name__ == "__main__":

--- a/src/clip_causal_repair/hooks.py
+++ b/src/clip_causal_repair/hooks.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LayerAddress:
+    """Simple address pointing to a submodule by its dotted path."""
+
+    name: str
+
+
+def resolve_modules(model: torch.nn.Module, addresses: Iterable[LayerAddress]) -> Dict[LayerAddress, torch.nn.Module]:
+    """Resolve a sequence of :class:`LayerAddress` objects to modules.
+
+    Parameters
+    ----------
+    model:
+        The root module to search within.
+    addresses:
+        Iterable of addresses describing submodules by their dotted names.
+
+    Returns
+    -------
+    dict
+        Mapping from each address to the resolved ``nn.Module`` instance.
+    """
+    module_dict = dict(model.named_modules())
+    resolved: Dict[LayerAddress, torch.nn.Module] = {}
+    for addr in addresses:
+        mod = module_dict.get(addr.name)
+        if mod is None:
+            raise KeyError(f"No submodule named {addr.name!r} in model")
+        resolved[addr] = mod
+    return resolved
+
+
+class HookManager:
+    """Utility to register and later remove forward hooks on modules.
+
+    Example
+    -------
+    >>> mgr = HookManager(model)
+    >>> mgr.register([LayerAddress("encoder.layer1")], hook_fn)
+    >>> ...  # run model
+    >>> mgr.remove()
+    """
+
+    def __init__(self, model: torch.nn.Module):
+        self.model = model
+        self._handles: List[torch.utils.hooks.RemovableHandle] = []
+
+    def register(self, addresses: Sequence[LayerAddress], hook: Callable):
+        """Register ``hook`` on all modules indicated by ``addresses``.
+
+        ``addresses`` may be a single :class:`LayerAddress` or a sequence of
+        them. The resolved modules are obtained via :func:`resolve_modules`.
+        """
+        if isinstance(addresses, LayerAddress):
+            addresses = [addresses]
+        modules = resolve_modules(self.model, addresses)
+        for addr, module in modules.items():
+            handle = module.register_forward_hook(hook)
+            logger.debug("Registered hook on %s", addr.name)
+            self._handles.append(handle)
+
+    def remove(self):
+        """Remove all registered hooks."""
+        while self._handles:
+            handle = self._handles.pop()
+            handle.remove()
+            logger.debug("Removed hook")
+
+    # Context-manager helpers
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.remove()
+
+
+def tensor_edit_projection_out(
+    t: torch.Tensor,
+    u: torch.Tensor,
+    alpha: float = 1.0,
+    token_scope: Optional[object] = None,
+) -> torch.Tensor:
+    """Project ``t`` away from direction ``u``.
+
+    Parameters
+    ----------
+    t:
+        Activation tensor of shape ``[B, d]`` or ``[B, T, d]``.
+    u:
+        Direction vector of shape ``[d]``.
+    alpha:
+        Scale of projection removal.
+    token_scope:
+        For 3D tensors, specifies which token positions to edit. Accepted
+        values are ``None``/"all" for all tokens, "last" for only the last
+        token, or an integer index/slice.
+
+    Returns
+    -------
+    torch.Tensor
+        Edited tensor. If the edit is skipped due to safety checks the
+        original tensor is returned unchanged.
+    """
+    if t.shape[-1] != u.shape[-1]:
+        logger.warning(
+            "tensor_edit_projection_out: mismatched dims t=%s u=%s", t.shape, u.shape
+        )
+        return t
+
+    u_norm = u.norm()
+    if torch.isnan(u_norm) or u_norm < 1e-6:
+        logger.warning("tensor_edit_projection_out: tiny edit direction; skipping")
+        return t
+
+    u_dir = u / u_norm
+
+    if t.ndim == 2:
+        v = t
+        proj_coeff = v @ u_dir
+        edited = v - alpha * proj_coeff.unsqueeze(-1) * u_dir
+        cos_before = F.cosine_similarity(v, u_dir.unsqueeze(0), dim=-1)
+        cos_after = F.cosine_similarity(edited, u_dir.unsqueeze(0), dim=-1)
+        logger.debug(
+            "projection_out: cos %.4f->%.4f | t_norm %.4f | u_norm %.4f",
+            cos_before.mean().item(),
+            cos_after.mean().item(),
+            v.norm(dim=-1).mean().item(),
+            u_norm.item(),
+        )
+        return edited
+
+    if t.ndim == 3:
+        if token_scope in (None, "all"):
+            idx = slice(None)
+        elif token_scope == "last":
+            idx = slice(-1, None)
+        elif isinstance(token_scope, int):
+            idx = slice(token_scope, token_scope + 1)
+        elif isinstance(token_scope, slice):
+            idx = token_scope
+        else:
+            logger.warning(
+                "tensor_edit_projection_out: unsupported token_scope %r", token_scope
+            )
+            return t
+
+        subset = t[:, idx, :]
+        proj_coeff = torch.matmul(subset, u_dir)
+        while proj_coeff.ndim < subset.ndim:
+            proj_coeff = proj_coeff.unsqueeze(-1)
+        edited = subset - alpha * proj_coeff * u_dir
+        cos_before = F.cosine_similarity(subset, u_dir, dim=-1)
+        cos_after = F.cosine_similarity(edited, u_dir, dim=-1)
+        logger.debug(
+            "projection_out: cos %.4f->%.4f | t_norm %.4f | u_norm %.4f",
+            cos_before.mean().item(),
+            cos_after.mean().item(),
+            subset.norm(dim=-1).mean().item(),
+            u_norm.item(),
+        )
+        out = t.clone()
+        out[:, idx, :] = edited
+        return out
+
+    logger.warning(
+        "tensor_edit_projection_out: unsupported tensor rank %d", t.ndim
+    )
+    return t


### PR DESCRIPTION
## Summary
- implement HookManager for registering and cleaning forward hooks via module addresses
- add tensor_edit_projection_out utility with safety checks and logging
- expose HookManager, LayerAddress, and tensor_edit_projection_out in the public API
- adapt feature_edit to use HookManager for layer-targeted edits
- update helper scripts to supply the layer argument

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f4c08968832299a7bb0810a90cb3